### PR TITLE
Update grammar and highlights for switch/case/default support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/stormwarning/zed-nunjucks"
 
 [grammars.nunjucks]
 repository = "https://github.com/stormwarning/tree-sitter-nunjucks"
-commit = "683a6e9b3c836f8e02a90ce6a348395f7f95e331"
+commit = "61a85ebd22f8b36ac517b57bd4fb1ec7a5cac83d"

--- a/languages/nunjucks/highlights.scm
+++ b/languages/nunjucks/highlights.scm
@@ -35,11 +35,15 @@
 	(identifier) @variable)
 
 [
+	"case"
+	"default"
 	"else"
 	"elif"
 	"elseif"
 	"endif"
+	"endswitch"
 	"if"
+	"switch"
 ] @keyword.conditional
 
 [

--- a/languages/nunjucks/spec.njk
+++ b/languages/nunjucks/spec.njk
@@ -71,6 +71,15 @@
 		may the force be with you
 	{% endfilter %}
 
+	{% switch foo %}
+		{% case "bar" %}
+			This is bar
+		{% case "baz" %}
+			This is baz
+		{% default %}
+			This is the default
+	{% endswitch %}
+
 	{% call add(1, 2) -%}
 		The result is
 	{%- endcall %}


### PR DESCRIPTION
Update tree-sitter-nunjucks to 61a85eb which adds switch_statement, case_statement, and default_statement grammar rules. Add corresponding highlight queries and spec examples.

Please note this commit is generated by Claude!